### PR TITLE
perf: optimize build options + improve to_camel() performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ name = "casers"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = "0.22.3"
+pyo3 = { version = "0.23.4", features = ["extension-module"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,10 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.23.4", features = ["extension-module"] }
+
+[profile.release]
+codegen-units = 1
+lto = "fat"
+opt-level = 3
+panic = "abort"
+strip = "symbols"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ use pyo3::prelude::*;
 
 /// Convert to camel case.
 #[pyfunction]
+#[inline(always)]
 fn to_camel(py: Python, s: &str) -> PyResult<String> {
     py.allow_threads(|| {
         let mut result = String::with_capacity(s.len());
@@ -23,6 +24,7 @@ fn to_camel(py: Python, s: &str) -> PyResult<String> {
 
 /// Convert to snake case.
 #[pyfunction]
+#[inline(always)]
 fn to_snake(py: Python, s: &str) -> PyResult<String> {
     py.allow_threads(move || {
         let mut result = String::with_capacity(s.len());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,19 +3,18 @@ use pyo3::prelude::*;
 /// Convert to camel case.
 #[pyfunction]
 fn to_camel(py: Python, s: &str) -> PyResult<String> {
-    py.allow_threads(move || {
+    py.allow_threads(|| {
         let mut result = String::with_capacity(s.len());
-        let mut capitalize_next = false;
-        for c in s.chars() {
-            if c == ' ' || c == '_' || c == '-' {
-                capitalize_next = true;
-            } else {
-                if capitalize_next {
-                    result.push(c.to_ascii_uppercase());
-                    capitalize_next = false;
-                } else {
-                    result.push(c.to_ascii_lowercase());
+        let mut s_iter = s.chars().peekable();
+        while let Some(c) = s_iter.next() {
+            match c {
+                ' ' | '_' | '-' => {
+                    if let Some(c_next) = s_iter.peek() {
+                        result.push(c_next.to_ascii_uppercase());
+                        s_iter.next();
+                    }
                 }
+                _ => result.push(c.to_ascii_lowercase()),
             }
         }
         Ok(result)


### PR DESCRIPTION
**I. def to_camel():**
before:
```rust
------------------------------------------------------------------------------------------------ benchmark: 7 tests -----------------------------------------------------------------------------------------------                                                                                                                                                                                                                 
Name (time in us)                             Min                 Max                Mean             StdDev              Median                IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------                                                                                                                                                                                                                 
test_to_camel_rust                         1.8730 (1.0)       32.6810 (2.36)       1.9430 (1.0)       0.2966 (2.80)       1.9339 (1.0)       0.0200 (1.0)      642;1667      514.6585 (1.0)       73551           1
test_to_snake_rust                         2.5540 (1.36)      13.8560 (1.0)        2.6237 (1.35)      0.1059 (1.0)        2.6150 (1.35)      0.0200 (1.0)     1696;3792      381.1365 (0.74)     143184           1
test_to_camel_python_builtin              10.9810 (5.86)      51.5760 (3.72)      11.3334 (5.83)      0.7716 (7.28)      11.2810 (5.83)      0.0900 (4.51)     715;1459       88.2347 (0.17)      44166           1
test_to_camel_python_builtin_parallel     44.1430 (23.57)    371.9180 (26.84)    129.3994 (66.60)    30.4607 (287.58)   140.9040 (72.86)    15.0680 (754.71)    524;541        7.7280 (0.02)       2326           1
test_to_camel_rust_parallel               45.0640 (24.06)    568.9870 (41.06)     71.9967 (37.05)    22.8562 (215.78)    65.5430 (33.89)    27.9870 (>1000.0)    202;14       13.8895 (0.03)       1648           1
test_to_camel_pure_python                 48.3800 (25.83)     89.6280 (6.47)      50.1310 (25.80)     1.6388 (15.47)     49.8840 (25.79)     0.4010 (20.08)    855;1579       19.9477 (0.04)      17869           1
test_to_snake_python_re                   80.1710 (42.80)     98.1340 (7.08)      82.1989 (42.30)     1.0949 (10.34)     82.0140 (42.41)     0.7042 (35.27)     775;570       12.1656 (0.02)       7837           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
after:
```rust
------------------------------------------------------------------------------------------------ benchmark: 7 tests ------------------------------------------------------------------------------------------------                                                                                                                                                                                                                
Name (time in us)                             Min                 Max                Mean             StdDev              Median                IQR             Outliers  OPS (Kops/s)            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------                                                                                                                                                                                                                
test_to_camel_rust                         1.4220 (1.0)       14.5480 (1.0)        1.4576 (1.0)       0.0720 (1.0)        1.4530 (1.0)       0.0190 (1.0)      1910;2658      686.0782 (1.0)       93459           1
test_to_snake_rust                         2.3740 (1.67)      36.2180 (2.49)       2.8336 (1.94)      1.2965 (18.01)      2.4250 (1.67)      0.0610 (3.21)     7187;8067      352.9099 (0.51)      79847           1
test_to_camel_python_builtin              11.1810 (7.86)      26.8700 (1.85)      11.3705 (7.80)      0.3120 (4.33)      11.3220 (7.79)      0.0701 (3.69)     1021;1493       87.9467 (0.13)      36628           1
test_to_camel_rust_parallel               29.9360 (21.05)    137.4670 (9.45)      45.1825 (31.00)     9.9856 (138.72)    43.1510 (29.70)     1.8629 (98.17)      380;570       22.1325 (0.03)       1769           1
test_to_camel_pure_python                 48.3800 (34.02)     67.9370 (4.67)      49.1363 (33.71)     0.9655 (13.41)     48.9220 (33.67)     0.3810 (20.08)    1212;1430       20.3516 (0.03)      18801           1
test_to_camel_python_builtin_parallel     62.2570 (43.78)    275.7270 (18.95)    132.2073 (90.70)    28.7426 (399.30)   139.5920 (96.07)    27.7910 (>1000.0)   1222;194        7.5639 (0.01)       5398           1
test_to_snake_python_re                   80.6920 (56.75)     92.6830 (6.37)      83.0365 (56.97)     1.1717 (16.28)     82.8850 (57.04)     1.2530 (66.03)     1455;295       12.0429 (0.02)       7080           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
Performance improvement summary:
  - *test_to_camel_rust()* median: `((1.9339 - 1.4530) / 1.9339) * 100 = 24.9%`
  - *test_to_camel_rust_parallel()* median: `((65.5430 - 43.1510) / 65.5430) * 100 = 34.2%`
___
**II. Library size**:
  - before: 503Kb
  - after: 362Kb